### PR TITLE
fix: add missing token for release workflow

### DIFF
--- a/.github/workflows/release_falco.yaml
+++ b/.github/workflows/release_falco.yaml
@@ -58,6 +58,7 @@ jobs:
         with:
           run-id: ${{ steps.latest_build_workflow_run.outputs.id }}
           pattern: falco-${{ steps.version.outputs.falco_version }}-*
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release
         uses: softprops/action-gh-release@v2.5.0


### PR DESCRIPTION
### Overview

Add missing `github_token` for download_artifact step. This seems to be required when downloading artifact from another workflow.

### Rationale

The release falco job found not artifact but it apparently has the artifact

build: https://github.com/canonical/falco-operator/actions/runs/19854249692
release: https://github.com/canonical/falco-operator/actions/runs/19856263914

### Checklist

- [ ] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm/charm-development-best-practices/) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD014 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The `docs/changelog.md` is updated with user-relevant changes.

Other unchecked box are irrelavent