### PR TITLE
Fix publish workflow for falcosidekick-k8s-operator

### DIFF
--- a/falcosidekick-k8s-operator/charmcraft.yaml
+++ b/falcosidekick-k8s-operator/charmcraft.yaml
@@ -36,9 +36,9 @@ config:
 
 containers:
   falcosidekick:
-    resource: falcosidekick
+    resource: falcosidekick-image
 
 resources:
-  falcosidekick:
+  falcosidekick-image:
     type: oci-image
     description: OCI image for the falcosidekick container

--- a/falcosidekick-k8s-operator/tests/integration/test_charm.py
+++ b/falcosidekick-k8s-operator/tests/integration/test_charm.py
@@ -13,7 +13,7 @@ import pytest
 logger = logging.getLogger(__name__)
 
 FALCOSIDEKICK_APP = "falcosidekick"
-FALCOSIDEKICK_IMAGE = "falcosidekick"
+FALCOSIDEKICK_IMAGE = "falcosidekick-image"
 
 
 def test_deploy_charms(juju: jubilant.Juju, charm: str, pytestconfig: pytest.Config):


### PR DESCRIPTION
### Overview

To properly release k8s charm, the resource name should have suffix [`-image`](https://github.com/canonical/operator-workflows/blob/main/src/publish.ts#L143) or use resource-mapping in the [workflow file](https://github.com/canonical/operator-workflows/blob/main/.github/workflows/publish_charm.yaml#L42) 

### Checklist

- [ ] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm/charm-development-best-practices/) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD014 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The `docs/changelog.md` is updated with user-relevant changes.
