### PR TITLE
Fix auto_update_libs workflow

### DIFF
--- a/.github/workflows/auto_update_libs.yaml
+++ b/.github/workflows/auto_update_libs.yaml
@@ -8,3 +8,10 @@ jobs:
   auto-update-libs:
     uses: canonical/operator-workflows/.github/workflows/auto_update_charm_libs.yaml@main
     secrets: inherit
+    strategy:
+      matrix:
+        include:
+          - charm: "falco"
+          - charm: "falcosidekick-k8s"
+    with:
+      working-directory: "${{ matrix.charm }}-operator"


### PR DESCRIPTION
### Overview

Update the auto-update_libs workflow in the charm subdirectory.

### Rationale

This workflow has been failing since migration to mono repo.

### Checklist

- [ ] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm/charm-development-best-practices/) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD014 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
