### PR TITLE
Implement automated TLS trust via http-endpoint relation

### DIFF
--- a/docs/tutorial/deploy-falcosidekick.md
+++ b/docs/tutorial/deploy-falcosidekick.md
@@ -46,7 +46,9 @@ mkdir -p ~/.kube
 juju run k8s/0 get-kubeconfig | yq -r '.kubeconfig' > ~/.kube/config
 
 EXTERNAL_IP=$(juju show-unit -m concierge-lxd:admin/falco-tutorial k8s/0 | yq -r '.k8s/0.public-address')
-juju bootstrap k8s k8s-controller --config controller-service-type=loadbalancer --config controller-external-ips=[$EXTERNAL_IP]
+juju bootstrap k8s k8s-controller \
+  --config controller-service-type=loadbalancer \
+  --config controller-external-ips='["'"$EXTERNAL_IP"'"]'
 ```
 
 When the bootstrap is complete, you should see a new controller listed:

--- a/falco-operator/pyproject.toml
+++ b/falco-operator/pyproject.toml
@@ -60,7 +60,7 @@ integration = [
 package = false
 
 [tool.uv.sources]
-pfe-interfaces-falcosidekick-http-endpoint = { git = "https://github.com/canonical/falco-operators", subdirectory = "interfaces/falcosidekick_http_endpoint", rev = "3c478ac8465094e5470e96f401aa2db7ca395be9" }
+pfe-interfaces-falcosidekick-http-endpoint = { git = "https://github.com/jjimenezgarcia/falco-operators", subdirectory = "interfaces/falcosidekick_http_endpoint", branch = "cert_manage" }
 
 [tool.ruff]
 target-version = "py310"

--- a/falco-operator/src/charm.py
+++ b/falco-operator/src/charm.py
@@ -95,13 +95,12 @@ class Falco(CharmBaseWithState):
 
     def reconcile(self, _: ops.EventBase) -> None:
         """Reconcile the charm state."""
-        # Configure TLS CA trust
-        if self.state.ca_cert:
-            ca_updated = self.falco_service.update_ca(self.state.ca_cert)
-            if ca_updated:
-                logger.info("System CA store updated, Falco will now trust Sidekick")
-
         try:
+            # Configure TLS CA trust
+            if self.state.ca_cert:
+                ca_updated = self.falco_service.update_ca(self.state.ca_cert)
+                if ca_updated:
+                    logger.info("System CA store updated, Falco will now trust Sidekick")
             self.falco_service.configure(self.state)
         except InvalidCharmConfigError:
             self.unit.status = ops.BlockedStatus("Invalid charm config")

--- a/falco-operator/src/charm.py
+++ b/falco-operator/src/charm.py
@@ -95,6 +95,12 @@ class Falco(CharmBaseWithState):
 
     def reconcile(self, _: ops.EventBase) -> None:
         """Reconcile the charm state."""
+        # Configure TLS CA trust
+        if self.state.ca_cert:
+            ca_updated = self.falco_service.update_ca(self.state.ca_cert)
+            if ca_updated:
+                logger.info("System CA store updated, Falco will now trust Sidekick")
+
         try:
             self.falco_service.configure(self.state)
         except InvalidCharmConfigError:

--- a/falco-operator/src/service.py
+++ b/falco-operator/src/service.py
@@ -328,6 +328,31 @@ class FalcoService:
 
         logger.info("Falco service removed")
 
+    def update_ca(self, ca_cert: str) -> bool:
+        """Install Falcosidekick CA.
+
+        Args:
+            ca_cert (str): CA certificate
+        """
+        if not ca_cert:
+            return False
+
+        ca_path = Path("/usr/local/share/ca-certificates/falcosidekick.crt")
+
+        if ca_path.exists() and ca_path.read_text() == ca_cert:
+            return False
+
+        logger.info("Installing new CA certificate for Falcosidekick")
+
+        ca_path.write_text(ca_cert)
+
+        try:
+            subprocess.run(["/usr/sbin/update-ca-certificates", "--fresh"], check=True)
+            return True
+        except subprocess.CalledProcessError as e:
+            logger.error("Failed to update system certificates: %s", e)
+            return False
+
     def configure(self, charm_state: state.CharmState) -> None:
         """Configure the Falco service.
 

--- a/falco-operator/src/state.py
+++ b/falco-operator/src/state.py
@@ -25,12 +25,14 @@ class CharmState(BaseModel):
         custom_config_repo_ref: Optional branch or tag to a custom configuration repository.
         custom_config_repo_ssh_key: Optional SSH key for custom configuration repository.
         http_output: Optional HTTP output data from http-output relation.
+        ca_cert: Optional CA cert to trust for HTTPs communications.
     """
 
     custom_config_repo: Optional[AnyUrl] = None
     custom_config_repo_ref: Optional[str] = None
     custom_config_repo_ssh_key: Optional[str] = None
     http_output: Optional[dict[str, str]] = None
+    ca_cert: Optional[str] = None
 
     @classmethod
     def from_charm(
@@ -68,18 +70,30 @@ class CharmState(BaseModel):
         custom_config_repo_ssh_key = _fetch_custom_ssh_key(charm.model, charm_config)
 
         http_output = {}
-        app_urls = http_endpoint_requirer.get_app_urls()
-        for url in app_urls.values():
+        ca_cert = None
+
+        # TODO: Remove ignore once the interface PR is merged and the revision updated in pyproject.toml
+        endpoints = http_endpoint_requirer.get_endpoints()  # type: ignore[attr-defined]
+        for data in endpoints.values():
             # There should only be one URL since this relation is limited to 1, but if there are
             # multiple, just take the last one.
-            http_output.update({"url": url})
-            logger.info("Retrieved url info from relation: %s", url)
+            http_output.update({"url": data["url"]})
+
+            # If there's a CA, store it
+            ca_cert = data.get("ca_cert")
+
+            logger.info(
+                "Retrieved endpoint info from relation. URL: %s, Has CA: %s",
+                data["url"],
+                bool(ca_cert),
+            )
 
         return cls(
             custom_config_repo=custom_config_repo,
             custom_config_repo_ref=custom_config_repo_ref,
             custom_config_repo_ssh_key=custom_config_repo_ssh_key,
             http_output=http_output,
+            ca_cert=ca_cert,
         )
 
 

--- a/falco-operator/uv.lock
+++ b/falco-operator/uv.lock
@@ -306,7 +306,7 @@ requires-dist = [
     { name = "cosl", specifier = ">=1.4.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "ops", specifier = "==3.5.2" },
-    { name = "pfe-interfaces-falcosidekick-http-endpoint", git = "https://github.com/canonical/falco-operators?subdirectory=interfaces%2Ffalcosidekick_http_endpoint&rev=3c478ac8465094e5470e96f401aa2db7ca395be9" },
+    { name = "pfe-interfaces-falcosidekick-http-endpoint", git = "https://github.com/jjimenezgarcia/falco-operators?subdirectory=interfaces%2Ffalcosidekick_http_endpoint&branch=cert_manage" },
     { name = "pydantic", specifier = ">=2.12.5" },
 ]
 
@@ -674,7 +674,7 @@ wheels = [
 [[package]]
 name = "pfe-interfaces-falcosidekick-http-endpoint"
 version = "1.0.0"
-source = { git = "https://github.com/canonical/falco-operators?subdirectory=interfaces%2Ffalcosidekick_http_endpoint&rev=3c478ac8465094e5470e96f401aa2db7ca395be9#3c478ac8465094e5470e96f401aa2db7ca395be9" }
+source = { git = "https://github.com/jjimenezgarcia/falco-operators?subdirectory=interfaces%2Ffalcosidekick_http_endpoint&branch=cert_manage#660a3d4f562a31ae798aafdb8424a99b56a53a34" }
 dependencies = [
     { name = "ops" },
     { name = "pydantic" },

--- a/falcosidekick-k8s-operator/pyproject.toml
+++ b/falcosidekick-k8s-operator/pyproject.toml
@@ -61,7 +61,7 @@ integration = [
 package = false
 
 [tool.uv.sources]
-pfe-interfaces-falcosidekick-http-endpoint = { git = "https://github.com/canonical/falco-operators", subdirectory = "interfaces/falcosidekick_http_endpoint", rev = "3c478ac8465094e5470e96f401aa2db7ca395be9" }
+pfe-interfaces-falcosidekick-http-endpoint = { git = "https://github.com/jjimenezgarcia/falco-operators", subdirectory = "interfaces/falcosidekick_http_endpoint", branch = "cert_manage" }
 
 [tool.ruff]
 target-version = "py310"

--- a/falcosidekick-k8s-operator/src/state.py
+++ b/falcosidekick-k8s-operator/src/state.py
@@ -69,7 +69,7 @@ class CharmState(BaseModel):
             cert_requirer = cast(Any, charm).tls_certificate_requirer
             cert, _ = cert_requirer._get_assigned_cert_and_key()
             if cert:
-                ca_cert = cert.ca
+                ca_cert = cert.ca.decode() if isinstance(cert.ca, bytes) else str(cert.ca)
 
             _url = _get_loki_ingress_endpoint(loki_push_api_consumer)
             loki_endpoint = _url.path if _url and _url.path else "/loki/api/v1/push"

--- a/falcosidekick-k8s-operator/tests/unit/test_state.py
+++ b/falcosidekick-k8s-operator/tests/unit/test_state.py
@@ -197,5 +197,8 @@ class TestCharmState:
 
         # Assert
         assert state.http_endpoint_config["scheme"] == "https"
-        assert state.http_endpoint_config["ca_cert"] == "---BEGIN CERTIFICATE---\nFAKE-CA\n---END CERTIFICATE---"
+        assert (
+            state.http_endpoint_config["ca_cert"]
+            == "---BEGIN CERTIFICATE---\nFAKE-CA\n---END CERTIFICATE---"
+        )
         assert state.enable_tls is True

--- a/falcosidekick-k8s-operator/tests/unit/test_state.py
+++ b/falcosidekick-k8s-operator/tests/unit/test_state.py
@@ -51,7 +51,9 @@ class TestCharmState:
         mock_charm = MagicMock()
         mock_charm.load_config.return_value = CharmConfig(port=port)
 
-        mock_charm.certificates._get_assigned_cert_and_key.return_value = (None, None)
+        mock_certs = MagicMock()
+        mock_certs._get_assigned_cert_and_key.return_value = (None, None)
+        mock_charm.certificates = mock_certs
 
         mock_loki_relation = MagicMock()
         mock_loki_relation.loki_endpoints = []
@@ -147,7 +149,9 @@ class TestCharmState:
         mock_charm = MagicMock()
         mock_charm.load_config.return_value = CharmConfig(port=2801)
 
-        mock_charm.certificates._get_assigned_cert_and_key.return_value = (None, None)
+        mock_certs = MagicMock()
+        mock_certs._get_assigned_cert_and_key.return_value = (None, None)
+        mock_charm.certificates = mock_certs
 
         mock_loki_relation = MagicMock()
         mock_loki_relation.loki_endpoints = []
@@ -177,8 +181,10 @@ class TestCharmState:
 
         mock_cert = MagicMock()
         mock_cert.ca = "---BEGIN CERTIFICATE---\nFAKE-CA\n---END CERTIFICATE---"
-        
-        mock_charm.certificates._get_assigned_cert_and_key.return_value = (mock_cert, "fake-key")
+
+        mock_certs = MagicMock()
+        mock_certs._get_assigned_cert_and_key.return_value = (mock_cert, "fake-key")
+        mock_charm.certificates = mock_certs
 
         mock_loki_relation = MagicMock()
         mock_loki_relation.loki_endpoints = []

--- a/falcosidekick-k8s-operator/tests/unit/test_state.py
+++ b/falcosidekick-k8s-operator/tests/unit/test_state.py
@@ -51,9 +51,8 @@ class TestCharmState:
         mock_charm = MagicMock()
         mock_charm.load_config.return_value = CharmConfig(port=port)
 
-        mock_certs = MagicMock()
-        mock_certs._get_assigned_cert_and_key.return_value = (None, None)
-        mock_charm.certificates = mock_certs
+        mock_charm.tls_certificate_requirer = MagicMock()
+        mock_charm.tls_certificate_requirer._get_assigned_cert_and_key.return_value = (None, None)
 
         mock_loki_relation = MagicMock()
         mock_loki_relation.loki_endpoints = []
@@ -149,9 +148,8 @@ class TestCharmState:
         mock_charm = MagicMock()
         mock_charm.load_config.return_value = CharmConfig(port=2801)
 
-        mock_certs = MagicMock()
-        mock_certs._get_assigned_cert_and_key.return_value = (None, None)
-        mock_charm.certificates = mock_certs
+        mock_charm.tls_certificate_requirer = MagicMock()
+        mock_charm.tls_certificate_requirer._get_assigned_cert_and_key.return_value = (None, None)
 
         mock_loki_relation = MagicMock()
         mock_loki_relation.loki_endpoints = []
@@ -182,9 +180,12 @@ class TestCharmState:
         mock_cert = MagicMock()
         mock_cert.ca = "---BEGIN CERTIFICATE---\nFAKE-CA\n---END CERTIFICATE---"
 
-        mock_certs = MagicMock()
-        mock_certs._get_assigned_cert_and_key.return_value = (mock_cert, "fake-key")
-        mock_charm.certificates = mock_certs
+        assigned_cert_return = (mock_cert, "fake-key")
+
+        mock_charm.tls_certificate_requirer = MagicMock()
+        mock_charm.tls_certificate_requirer._get_assigned_cert_and_key.return_value = (
+            assigned_cert_return
+        )
 
         mock_loki_relation = MagicMock()
         mock_loki_relation.loki_endpoints = []

--- a/falcosidekick-k8s-operator/uv.lock
+++ b/falcosidekick-k8s-operator/uv.lock
@@ -425,7 +425,7 @@ requires-dist = [
     { name = "cosl", specifier = ">=1.4.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "ops", specifier = "==3.5.2" },
-    { name = "pfe-interfaces-falcosidekick-http-endpoint", git = "https://github.com/canonical/falco-operators?subdirectory=interfaces%2Ffalcosidekick_http_endpoint&rev=3c478ac8465094e5470e96f401aa2db7ca395be9" },
+    { name = "pfe-interfaces-falcosidekick-http-endpoint", git = "https://github.com/jjimenezgarcia/falco-operators?subdirectory=interfaces%2Ffalcosidekick_http_endpoint&branch=cert_manage" },
     { name = "pydantic", specifier = ">=2.12.5" },
 ]
 
@@ -794,7 +794,7 @@ wheels = [
 [[package]]
 name = "pfe-interfaces-falcosidekick-http-endpoint"
 version = "1.0.0"
-source = { git = "https://github.com/canonical/falco-operators?subdirectory=interfaces%2Ffalcosidekick_http_endpoint&rev=3c478ac8465094e5470e96f401aa2db7ca395be9#3c478ac8465094e5470e96f401aa2db7ca395be9" }
+source = { git = "https://github.com/jjimenezgarcia/falco-operators?subdirectory=interfaces%2Ffalcosidekick_http_endpoint&branch=cert_manage#660a3d4f562a31ae798aafdb8424a99b56a53a34" }
 dependencies = [
     { name = "ops" },
     { name = "pydantic" },


### PR DESCRIPTION

### Overview
This PR introduces automated CA propagation through the http-endpoint relation interface.
When Falcosidekick exposes an HTTPS endpoint signed by a private or self-managed CA, the corresponding CA certificate is now published via the relation and automatically installed into Falco’s system trust store.
This enables Falco to validate TLS connections to Falcosidekick without requiring manual certificate distribution or configuration.

### Rationale
Previously, when Falcosidekick was configured with TLS using a private or self-signed CA, Falco required manual trust configuration or additional operational steps to validate the connection.

This change aligns the integration with secure-by-default principles by ensuring that TLS identity validation is automatically and correctly configured through Juju relations.

### Juju Events Changes

- config_changed: Priority logic adjusted to ensure security data obtained via relation (SAAS or local) prevails over static configurations.

### Module Changes

- CharmState):  include ca_cert as an optional field. Refined the from_charm method to process the new data structure of the interface.

### Library Changes

falcosidekick_http_endpoint:

    - Implemented the get_endpoints() method in the Requirer class to facilitate access to multiple units or endpoints.
    - Updated data transfer logic to include the ca_cert field in the exchange between applications.

### Checklist

- [ ] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm/charm-development-best-practices/) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD014 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The `docs/changelog.md` is updated with user-relevant changes.
