### PR TITLE
Disable jubilant logging for juju.deploy, juju.config and juju.exec

### DIFF
--- a/falco-operator/tests/integration/conftest.py
+++ b/falco-operator/tests/integration/conftest.py
@@ -21,7 +21,9 @@ def charm_fixture(pytestconfig: pytest.Config):
 
 
 @pytest.fixture(scope="session", name="juju")
-def juju_fixture(request: pytest.FixtureRequest) -> Generator[jubilant.Juju, None, None]:
+def juju_fixture(
+    request: pytest.FixtureRequest,
+) -> Generator[jubilant.Juju, None, None]:
     """Pytest fixture that wraps :meth:`jubilant.with_model`."""
 
     def show_debug_log(juju: jubilant.Juju):

--- a/falco-operator/tests/integration/test_charm.py
+++ b/falco-operator/tests/integration/test_charm.py
@@ -24,9 +24,7 @@ def test_deploy_charms(juju: jubilant.Juju, charm: str, pytestconfig: pytest.Con
     Act: Integrate falco charm with the principal charm.
     Assert: Both applications are deployed and active.
     """
-    logger.info(
-        "Deploying %s with constraints: %s", PRINCIPAL_APP, PRINCIAPL_APP_CONSTRAINTS
-    )
+    logger.info("Deploying %s with constraints: %s", PRINCIPAL_APP, PRINCIAPL_APP_CONSTRAINTS)
     juju.deploy(
         PRINCIPAL_APP,
         app=PRINCIPAL_APP,
@@ -129,25 +127,17 @@ def test_remove_integration(juju: jubilant.Juju):
     """
     logger.info("Removing integration between %s and %s", PRINCIPAL_APP, FALCO_APP)
     juju.remove_relation(PRINCIPAL_APP, FALCO_APP)
-    juju.wait(
-        lambda status: status.apps[PRINCIPAL_APP].is_active, timeout=juju.wait_timeout
-    )
+    juju.wait(lambda status: status.apps[PRINCIPAL_APP].is_active, timeout=juju.wait_timeout)
 
     principal_units = juju.status().get_units(PRINCIPAL_APP)
     for unit_name in principal_units:
         logger.info("Checking if falco service is stopped in unit %s", unit_name)
         result = juju.ssh(unit_name, "systemctl is-active falco || echo 'inactive'")
-        assert (
-            "inactive" in result or "failed" in result
-        ), "Falco service should be inactive"
+        assert "inactive" in result or "failed" in result, "Falco service should be inactive"
 
-        logger.info(
-            "Checking if falco systemd service file is removed in unit %s", unit_name
-        )
+        logger.info("Checking if falco systemd service file is removed in unit %s", unit_name)
         result = juju.ssh(
             unit_name,
             "test -f /etc/systemd/system/falco.service && echo 'exists' || echo 'missing'",
         )
-        assert (
-            "missing" in result.strip()
-        ), "Falco systemd service file should be removed"
+        assert "missing" in result.strip(), "Falco systemd service file should be removed"

--- a/falco-operator/tests/integration/test_charm.py
+++ b/falco-operator/tests/integration/test_charm.py
@@ -24,17 +24,20 @@ def test_deploy_charms(juju: jubilant.Juju, charm: str, pytestconfig: pytest.Con
     Act: Integrate falco charm with the principal charm.
     Assert: Both applications are deployed and active.
     """
-    logger.info("Deploying %s with constraints: %s", PRINCIPAL_APP, PRINCIAPL_APP_CONSTRAINTS)
+    logger.info(
+        "Deploying %s with constraints: %s", PRINCIPAL_APP, PRINCIAPL_APP_CONSTRAINTS
+    )
     juju.deploy(
         PRINCIPAL_APP,
         app=PRINCIPAL_APP,
         num_units=PRINCIPAL_APP_UNITS,
         base=pytestconfig.getoption("--base"),
         constraints=PRINCIAPL_APP_CONSTRAINTS,
+        log=False,
     )
 
     logger.info("Deploying %s", FALCO_APP)
-    juju.deploy(charm, app=FALCO_APP)
+    juju.deploy(charm, app=FALCO_APP, log=False)
 
     logger.info("Integrating %s with %s", PRINCIPAL_APP, FALCO_APP)
     juju.integrate(PRINCIPAL_APP, FALCO_APP)
@@ -126,17 +129,25 @@ def test_remove_integration(juju: jubilant.Juju):
     """
     logger.info("Removing integration between %s and %s", PRINCIPAL_APP, FALCO_APP)
     juju.remove_relation(PRINCIPAL_APP, FALCO_APP)
-    juju.wait(lambda status: status.apps[PRINCIPAL_APP].is_active, timeout=juju.wait_timeout)
+    juju.wait(
+        lambda status: status.apps[PRINCIPAL_APP].is_active, timeout=juju.wait_timeout
+    )
 
     principal_units = juju.status().get_units(PRINCIPAL_APP)
     for unit_name in principal_units:
         logger.info("Checking if falco service is stopped in unit %s", unit_name)
         result = juju.ssh(unit_name, "systemctl is-active falco || echo 'inactive'")
-        assert "inactive" in result or "failed" in result, "Falco service should be inactive"
+        assert (
+            "inactive" in result or "failed" in result
+        ), "Falco service should be inactive"
 
-        logger.info("Checking if falco systemd service file is removed in unit %s", unit_name)
+        logger.info(
+            "Checking if falco systemd service file is removed in unit %s", unit_name
+        )
         result = juju.ssh(
             unit_name,
             "test -f /etc/systemd/system/falco.service && echo 'exists' || echo 'missing'",
         )
-        assert "missing" in result.strip(), "Falco systemd service file should be removed"
+        assert (
+            "missing" in result.strip()
+        ), "Falco systemd service file should be removed"

--- a/falcosidekick-k8s-operator/tests/integration/conftest.py
+++ b/falcosidekick-k8s-operator/tests/integration/conftest.py
@@ -21,7 +21,9 @@ def charm_fixture(pytestconfig: pytest.Config):
 
 
 @pytest.fixture(scope="session", name="juju")
-def juju_fixture(request: pytest.FixtureRequest) -> Generator[jubilant.Juju, None, None]:
+def juju_fixture(
+    request: pytest.FixtureRequest,
+) -> Generator[jubilant.Juju, None, None]:
     """Pytest fixture that wraps :meth:`jubilant.with_model`."""
 
     def show_debug_log(juju: jubilant.Juju):

--- a/falcosidekick-k8s-operator/tests/integration/test_charm.py
+++ b/falcosidekick-k8s-operator/tests/integration/test_charm.py
@@ -35,9 +35,7 @@ def test_deploy_charms(juju: jubilant.Juju, charm: str, pytestconfig: pytest.Con
     logger.info("Deploying %s", FALCOSIDEKICK_K8S)
     juju.deploy(
         charm,
-        resources={
-            FALCOSIDEKICK_IMAGE: pytestconfig.getoption("--falcosidekick-image")
-        },
+        resources={FALCOSIDEKICK_IMAGE: pytestconfig.getoption("--falcosidekick-image")},
         app=FALCOSIDEKICK_K8S,
         log=False,
     )
@@ -57,14 +55,10 @@ def test_deploy_charms(juju: jubilant.Juju, charm: str, pytestconfig: pytest.Con
     )
 
     logger.info("Relating %s and %s", FALCOSIDEKICK_K8S, GRAFANA_AGENT_K8S)
-    juju.integrate(
-        f"{FALCOSIDEKICK_K8S}:send-loki-logs", f"{GRAFANA_AGENT_K8S}:logging-provider"
-    )
+    juju.integrate(f"{FALCOSIDEKICK_K8S}:send-loki-logs", f"{GRAFANA_AGENT_K8S}:logging-provider")
 
     logger.info("Relating %s and %s", FALCOSIDEKICK_K8S, SELF_SIGNED_CERTIFICATE)
-    juju.integrate(
-        f"{FALCOSIDEKICK_K8S}:certificates", f"{SELF_SIGNED_CERTIFICATE}:certificates"
-    )
+    juju.integrate(f"{FALCOSIDEKICK_K8S}:certificates", f"{SELF_SIGNED_CERTIFICATE}:certificates")
 
     logger.info("Waiting for deployment to settle")
     juju.wait(
@@ -131,10 +125,7 @@ def test_config_change_invalid_port(juju: jubilant.Juju):
 
     status = juju.status()
     assert status.apps[FALCOSIDEKICK_K8S].app_status.current == "blocked"
-    assert (
-        "Invalid charm configuration"
-        in status.apps[FALCOSIDEKICK_K8S].app_status.message
-    )
+    assert "Invalid charm configuration" in status.apps[FALCOSIDEKICK_K8S].app_status.message
 
     logger.info("Resetting charm config")
     juju.config(FALCOSIDEKICK_K8S, reset=["port"], log=False)

--- a/falcosidekick-k8s-operator/tests/integration/test_charm.py
+++ b/falcosidekick-k8s-operator/tests/integration/test_charm.py
@@ -35,27 +35,36 @@ def test_deploy_charms(juju: jubilant.Juju, charm: str, pytestconfig: pytest.Con
     logger.info("Deploying %s", FALCOSIDEKICK_K8S)
     juju.deploy(
         charm,
-        resources={FALCOSIDEKICK_IMAGE: pytestconfig.getoption("--falcosidekick-image")},
+        resources={
+            FALCOSIDEKICK_IMAGE: pytestconfig.getoption("--falcosidekick-image")
+        },
         app=FALCOSIDEKICK_K8S,
+        log=False,
     )
     logger.info("Deploying %s", GRAFANA_AGENT_K8S)
     juju.deploy(
         GRAFANA_AGENT_K8S,
         channel=GRAFANA_AGENT_K8S_CHANNEL,
         revision=GRAFANA_AGENT_K8S_REVISION,
+        log=False,
     )
     logger.info("Deploying %s", SELF_SIGNED_CERTIFICATE)
     juju.deploy(
         SELF_SIGNED_CERTIFICATE,
         channel=SELF_SIGNED_CERTIFICATE_CHANNEL,
         revision=SELF_SIGNED_CERTIFICATE_REVISION,
+        log=False,
     )
 
     logger.info("Relating %s and %s", FALCOSIDEKICK_K8S, GRAFANA_AGENT_K8S)
-    juju.integrate(f"{FALCOSIDEKICK_K8S}:send-loki-logs", f"{GRAFANA_AGENT_K8S}:logging-provider")
+    juju.integrate(
+        f"{FALCOSIDEKICK_K8S}:send-loki-logs", f"{GRAFANA_AGENT_K8S}:logging-provider"
+    )
 
     logger.info("Relating %s and %s", FALCOSIDEKICK_K8S, SELF_SIGNED_CERTIFICATE)
-    juju.integrate(f"{FALCOSIDEKICK_K8S}:certificates", f"{SELF_SIGNED_CERTIFICATE}:certificates")
+    juju.integrate(
+        f"{FALCOSIDEKICK_K8S}:certificates", f"{SELF_SIGNED_CERTIFICATE}:certificates"
+    )
 
     logger.info("Waiting for deployment to settle")
     juju.wait(
@@ -81,7 +90,7 @@ def test_config_change_valid_port(juju: jubilant.Juju):
     Assert: Charm is active after port change and remains active after reset.
     """
     logger.info("Changing port to valid value 8080")
-    juju.config(FALCOSIDEKICK_K8S, {"port": "8080"})
+    juju.config(FALCOSIDEKICK_K8S, {"port": "8080"}, log=False)
 
     logger.info("Waiting for charm to settle after config change")
     juju.wait(
@@ -93,7 +102,7 @@ def test_config_change_valid_port(juju: jubilant.Juju):
     assert status.apps[FALCOSIDEKICK_K8S].app_status.current == "active"
 
     logger.info("Resetting charm config")
-    juju.config(FALCOSIDEKICK_K8S, reset=["port"])
+    juju.config(FALCOSIDEKICK_K8S, reset=["port"], log=False)
 
     logger.info("Waiting for charm to settle after config reset")
     juju.wait(
@@ -112,7 +121,7 @@ def test_config_change_invalid_port(juju: jubilant.Juju):
     Assert: Charm is blocked after invalid port change and active after reset.
     """
     logger.info("Changing port to invalid value 0")
-    juju.config(FALCOSIDEKICK_K8S, {"port": "0"})
+    juju.config(FALCOSIDEKICK_K8S, {"port": "0"}, log=False)
 
     logger.info("Waiting for charm to enter blocked status")
     juju.wait(
@@ -122,10 +131,13 @@ def test_config_change_invalid_port(juju: jubilant.Juju):
 
     status = juju.status()
     assert status.apps[FALCOSIDEKICK_K8S].app_status.current == "blocked"
-    assert "Invalid charm configuration" in status.apps[FALCOSIDEKICK_K8S].app_status.message
+    assert (
+        "Invalid charm configuration"
+        in status.apps[FALCOSIDEKICK_K8S].app_status.message
+    )
 
     logger.info("Resetting charm config")
-    juju.config(FALCOSIDEKICK_K8S, reset=["port"])
+    juju.config(FALCOSIDEKICK_K8S, reset=["port"], log=False)
 
     logger.info("Waiting for charm to return to active status")
     juju.wait(


### PR DESCRIPTION
Add log=False to all juju.deploy(), juju.config() and juju.exec() calls in integration tests.