### PR TITLE
chore(ci): add actions:read and contents:write permissions to publish workflows (charmkeeper)

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -4,22 +4,23 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+    - main
 
 jobs:
   publish-to-edge:
     uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
     secrets: inherit
     permissions:
-      contents: read
+      contents: write
       packages: write
+      actions: read
     strategy:
       matrix:
         include:
-          - charm: "falco"
-            channel: "0.42/edge"
-          - charm: "falcosidekick-k8s"
-            channel: "2/edge"
+        - charm: "falco"
+          channel: "0.42/edge"
+        - charm: "falcosidekick-k8s"
+          channel: "2/edge"
     with:
       channel: ${{ matrix.channel }}
       identifier: ${{ matrix.charm }}


### PR DESCRIPTION
This PR adds `actions: read` and `contents: write` permissions to GitHub Actions jobs that use the `canonical/operator-workflows/.github/workflows/publish_charm.yaml` reusable workflow or `canonical/charming-actions/upload-charm` action.
These permissions are required for the workflow to function correctly with the latest changes to the reusable workflow.