### PR TITLE
Fix tag names

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -19,9 +19,12 @@ jobs:
         include:
           - charm: "falco"
             channel: "0.42/edge"
+            tag-prefix: "falco"
           - charm: "falcosidekick-k8s"
             channel: "2/edge"
+            tag-prefix: "falcosidekick"
     with:
       channel: ${{ matrix.channel }}
       identifier: ${{ matrix.charm }}
       working-directory: './${{ matrix.charm }}-operator'
+      tag-prefix: ${{ matrix.include.tag-prefix }}


### PR DESCRIPTION
All tags are currently named "revXX" which result in publishing issues as falco and falcosidekick are not on the same revision anymore.