### PR TITLE
chore(docs): add Charmhub listing links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ In addition to charm related code, this repository also contains packages to the
 1. [`falco`](.github/workflows/build_falco.yaml): A customized Falco package built from source.
 2. [`falcocsidekick`](./falcosidekick-k8s-operator/rock): A customized Falcosidekick rock image built from source.
 
+## Charmhub
+
+| Name | Listing |
+|------|---------|
+| `falco` | https://charmhub.io/falco |
+| `falcosidekick-k8s` | https://charmhub.io/falcosidekick-k8s |
+
 ## Documentation
 
 Our documentation is stored in the `docs` directory and
@@ -46,13 +53,6 @@ make linkcheck
 make vale
 make lint-md
 ```
-
-## Charmhub
-
-| Name | Listing |
-|------|---------|
-| `falco` | https://charmhub.io/falco |
-| `falcosidekick-k8s` | https://charmhub.io/falcosidekick-k8s |
 
 ## Project and community
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ make vale
 make lint-md
 ```
 
+## Charmhub
+
+| Name | Listing |
+|------|---------|
+| `falco` | https://charmhub.io/falco |
+| `falcosidekick-k8s` | https://charmhub.io/falcosidekick-k8s |
+
 ## Project and community
 
 The Falco operators project is a member of the Ubuntu family. It is an open source project that warmly welcomes


### PR DESCRIPTION
#### What this PR does

Adds a table with Charmhub URLs for the charms in this monorepo.

#### Why we need it

Enables discoverability for both humans and LLMs.

#### Checklist

- [X] I used AI to assist with preparing this PR
